### PR TITLE
Added mocha exit flag in script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "NODE_ENV=production node server",
     "watch": "cross-env NODE_ENV=development node_modules/.bin/nodemon server",
     "lint": "node_modules/.bin/eslint .",
-    "test": "cross-env NODE_ENV=test node_modules/.bin/mocha server/tests/*test.js --reporter spec"
+    "test": "cross-env NODE_ENV=test node_modules/.bin/mocha server/tests/*test.js --exit --reporter spec"
   },
   "cacheDirectories": [
     "node_modules",


### PR DESCRIPTION
Apparently mocha needs --exit flag. With this enabled, travis managed to run the API/integration tests for user without getting a mongodb connection error ("connection reset by peer") halfway through the tests. Don't actually know if this was the cause but fingers crossed...